### PR TITLE
Closes #1: Add functional boot screen

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,6 +6,8 @@ rocktree=$(CURDIR)/rocks
 target=$(CURDIR)/target
 lib=$(rocktree)/share/lua/5.1
 
+rockserver=https://luarocks.org/dev
+
 rockspec=$(CURDIR)/$(name)-$(version).rockspec
 love=$(target)/$(name).love
 
@@ -17,7 +19,7 @@ $(target) $(rocktree) $(lib):
 	mkdir -p $@
 
 luarocks: | $(rocktree)
-	luarocks --tree=$(rocktree) install $(rockspec)
+	luarocks --server=$(rockserver) --tree=$(rocktree) install $(rockspec)
 
 love: luarocks | $(target) $(lib)
 	cd $(src) && zip -q9r $(love) .

--- a/practicar-0.0.0-1.rockspec
+++ b/practicar-0.0.0-1.rockspec
@@ -11,7 +11,9 @@ description = {
    license = ''
 }
 dependencies = {
-   'lua == 5.1'
+   'lua == 5.1',
+   'hump == scm-1',
+   'tiny-ecs == 1.3-3'
 }
 build = {
   type = "builtin",

--- a/src/conf.lua
+++ b/src/conf.lua
@@ -1,0 +1,11 @@
+local PRACTICAR = 'practicar'
+
+function love.conf(t)
+  t.identity     = PRACTICAR
+  t.window.title = PRACTICAR
+
+  t.modules.joystick = false
+  t.modules.math     = false
+  t.modules.physics  = false
+  t.modules.video    = false
+end

--- a/src/entity/boot/text.lua
+++ b/src/entity/boot/text.lua
@@ -1,0 +1,18 @@
+local class = require('hump.class')
+
+local Text = require('entity.text')
+
+local Entity = class()
+
+function Entity:init()
+  local font = love.graphics.newFont(36)
+  local text = Text('Begin', font)
+  local w, h = love.graphics.getCanvas():getDimensions()
+
+  text.x = w - text.w
+  text.y = h - text.h
+
+  self:include(text)
+end
+
+return Entity

--- a/src/entity/text.lua
+++ b/src/entity/text.lua
@@ -1,0 +1,13 @@
+local class = require('hump.class')
+
+local Entity = class()
+
+function Entity:init(text, font, x, y)
+  self.drawable  = love.graphics.newText(font, text)
+  self.w, self.h = self.drawable:getDimensions()
+
+  self.x = x or 0
+  self.y = y or 0
+end
+
+return Entity

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,0 +1,8 @@
+local Gamestate = require('hump.gamestate')
+
+local boot = require('state.boot')
+
+function love.load()
+  Gamestate.registerEvents()
+  Gamestate.switch(boot)
+end

--- a/src/mixin/state.lua
+++ b/src/mixin/state.lua
@@ -1,0 +1,16 @@
+local tiny = require('tiny')
+
+local drawFilter   = tiny.requireAll('isDrawSystem')
+local updateFilter = tiny.rejectAll(drawFilter)
+
+local Mixin = {}
+
+function Mixin:draw()
+  self.world:update(0, drawFilter)
+end
+
+function Mixin:update(dt)
+  self.world:update(dt, updateFilter)
+end
+
+return Mixin

--- a/src/state/boot.lua
+++ b/src/state/boot.lua
@@ -1,0 +1,32 @@
+local class = require('hump.class')
+local tiny  = require('tiny')
+
+local Text  = require('entity.boot.text')
+local Mixin = require('mixin.state')
+local Draw  = require('system.draw')
+
+local State = class():include(Mixin)
+
+function State:init()
+  self.world = tiny.world(Draw())
+
+  self.world:add(Text())
+end
+
+function State:boot()
+  love.event.quit()
+end
+
+function State:mousepressed()
+  self:boot()
+end
+
+function State:keypressed()
+  self:boot()
+end
+
+function State:touchpressed()
+  self:boot()
+end
+
+return State

--- a/src/system/draw.lua
+++ b/src/system/draw.lua
@@ -1,0 +1,36 @@
+local class = require('hump.class')
+local tiny  = require('tiny')
+
+local System = tiny.processingSystem(class())
+
+local GAMEBOY_WIDTH  = 160
+local GAMEBOY_HEIGHT = 144
+
+function System:init()
+  self.filter = tiny.requireAll('drawable', 'x', 'y')
+  self.canvas = love.graphics.newCanvas(GAMEBOY_WIDTH, GAMEBOY_HEIGHT)
+  self.isDrawSystem = true
+
+  love.graphics.setCanvas(self.canvas)
+end
+
+function System:preWrap(dt)
+  love.graphics.setCanvas(self.canvas)
+  love.graphics.clear()
+end
+
+function System:process(e, dt)
+  love.graphics.draw(e.drawable, e.x, e.y)
+end
+
+function System:postWrap(dt)
+  local w, h = love.window.getMode()
+  local sx = w / GAMEBOY_WIDTH
+  local sy = h / GAMEBOY_HEIGHT
+
+  love.graphics.setCanvas()
+  love.graphics.scale(sx, sy)
+  love.graphics.draw(self.canvas)
+end
+
+return System


### PR DESCRIPTION
- Initialize hump.gamestate on boot state in love.load()
- Initialize tiny.world on boot state initialization
- Draw boot text entity on boot screen
- Stub function switching to menu state on any user input, exit game